### PR TITLE
Update bitstamp.js

### DIFF
--- a/bitstamp.js
+++ b/bitstamp.js
@@ -38,9 +38,6 @@ Bitstamp.prototype._request = function(method, path, data, callback, args) {
   }
 
   var req = https.request(options, function(res) {
-    res.on('error', function(err) {
-      callback(err)
-    });
     res.setEncoding('utf8');
     var buffer = '';
     res.on('data', function(data) {
@@ -54,6 +51,9 @@ Bitstamp.prototype._request = function(method, path, data, callback, args) {
       }
       callback(null, json);
     });
+  });
+  req.on('error', function(err) {
+    callback(err);
   });
   req.end(data);
 }


### PR DESCRIPTION
Double-checked with official documentation:

http://nodejs.org/api/https.html#https_https_request_options_callback

Should use req.on('error') for error handling.
