### PR TITLE
fix for when miliseconds < 100

### DIFF
--- a/bitstamp.js
+++ b/bitstamp.js
@@ -81,7 +81,7 @@ Bitstamp.prototype._post = function(action, callback, args) {
 
   var path = '/api/' + action + '/';
 
-  var nonce = new Date().getTime() + '' + (new Date().getMilliseconds() + 1000);
+  var nonce = '' + new Date().getTime();
   var message = nonce + this.client_id + this.key;
   var signer = crypto.createHmac('sha256', new Buffer(this.secret, 'utf8'));
   var signature = signer.update(message).digest('hex').toUpperCase();


### PR DESCRIPTION
When milliseconds are below 100, there is no zero padding - this is a quick fix.
