### PR TITLE
Changed timedelta to limit to match Bitstamp API.

### DIFF
--- a/bitstamp.js
+++ b/bitstamp.js
@@ -163,12 +163,12 @@ Bitstamp.prototype.balance = function(callback) {
   this._post('balance', callback);
 }
 
-Bitstamp.prototype.user_transactions = function(timedelta, callback) {
+Bitstamp.prototype.user_transactions = function(limit, callback) {
   if(!callback) {
-    callback = timedelta;
-    timedelta = undefined;
+    callback = limit;
+    limit = undefined;
   }
-  this._post('user_transactions', callback, {timedelta: timedelta});
+  this._post('user_transactions', callback, {limit: limit});
 }
 
 Bitstamp.prototype.open_orders = function(callback) {


### PR DESCRIPTION
Timedelta does not exist as a param for this API call. See commit.
